### PR TITLE
Manual speed setting shows RPM, stuff towards a two fan support, minor stuff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 KDIR ?= /lib/modules/$(shell uname -r)/build
 obj-m := asus-wmi.o asus-nb-wmi.o
 
-all:
+SRCS=asus-wmi.c asus-nb-wmi.c asus-wmi.h asus-nb-wmi.c
+
+all: $(SRCS)
 	make -C $(KDIR) M=$$PWD modules
 
 install:


### PR DESCRIPTION
- having a RPM value while in manual mode seems pretty important for me, so faking it (again ;), 
  - less sophisticated, keep-it-simple linear scaling `[offset ... offset+coeff*255]`
  - Far from realistic or perfect, but really needed (IMHO) for fan controlling even if imprecise/wrong
  - (from my feeling a PID mostly compensates this anyways)
- realized like this:
  - Removed the `asus_hwmon_fan_manual_mode` manual_mode flag 
  - Added `fan{1,2}_manual_speed`, `fan{1,2}_{offset,coeff}_rpm`
  - `fan{1,2}_manual_speed` are either "-1" (auto-mode) or a specific (manual set) value
  - now returning some calculated RPM value on read instead of -1
- minor:
  - included `fan == 2` in some ifs---in preparation for real two-fan-support
  - added SRC to Makefile, sometimes `make` did not recognize changes inside the source files

What do you think? Nice? Or strictly no manual-speed-calculation-magic?
